### PR TITLE
Update _references.md

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -40,3 +40,5 @@
 [community package repositories]: http://cfengine.com/cfengine-linux-distros
 [community download page]: https://cfengine.com/inside/myspace
 [enterprise software download page]: https://cfengine.com/software
+[design center-reference]: reference-design-center.html "Design Center Reference"
+[design center-using]: manuals-design-center.html "Using the Design Center"


### PR DESCRIPTION
Created references for Design Center to distinguish between learning how to use the DC and "DC References." Also, the title of the Design Center (manuals-design-center.html) is changing so this is a good time to create a reference name for it.
