### PR TITLE
Change: Error message for missing ALIAS

### DIFF
--- a/_plugins/sitemap_generator.rb
+++ b/_plugins/sitemap_generator.rb
@@ -91,6 +91,7 @@ module Jekyll
       else
         puts "--------------------------------------------------------"
         puts "ERROR: ALIAS FOR THE PAGE: " +  page.name + " is not set"  
+        puts "       Potentially because the page is not published    "
         puts "--------------------------------------------------------"
       end    
     end


### PR DESCRIPTION
This seems to be generated for pages that are unpublished. This makes
the condition a bit more clear.