### PR TITLE
Attempt to fix link in vagrant docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ CFE_DIR: _site
 CFE_manuals_version: 3.8
 cfengine:
   branch: 3.8
-  latest_patch_release: 0b1
+  latest_patch_release: "0b1"
   latest_package_build: 1
 
 paginate: 500


### PR DESCRIPTION
latest_patch_release was rendering as 1, instead of 0b1.