### PR TITLE
Add: Reference for `collecting functions`

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -41,3 +41,5 @@
 [body classes]: reference-promise-types.html#classes
 [body common]: reference-components.html#common-control
 [body file]: guide-language-concepts-namespaces.html
+[collecting functions]: reference-functions.html:#collecting-functions
+


### PR DESCRIPTION
Trying to fix the doc build which was broken around the time this new
section was added. Build errors with <unknown> key from
`_plugins/references.rb`