### PR TITLE
CFE-2965 Add link reference to sys.uqhost

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -37,3 +37,4 @@
 [sys.policy_entry_filename]: reference-special-variables-sys.html#sys-policy_entry_filename
 [supported versions]: https://cfengine.com/extended-support/
 [Inventory API]: reference-enterprise-api-ref-inventory.html
+[sys.uqhost]: reference-special-variables-sys.html#sys-uqhost


### PR DESCRIPTION
sys.fqhost links to sys.uqhost, but the link is broken. Probably because it
falls later on the same page and it isn't properly resolved. We have had to do
similar for sys.policy_entry_dirname and sys.policy_entry_filename in the past.

This change adds a reference link for sys.uqhost so that it will be sure to
resolve.