### PR TITLE
CFE-2965 Add link reference to sys.uqhost

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -42,3 +42,4 @@
 [body common]: reference-components.html#common-control
 [body file]: guide-language-concepts-namespaces.html
 [body hub control port]: reference-components-cf-hub.html#port
+[sys.uqhost]: reference-special-variables-sys.html#sys-uqhost


### PR DESCRIPTION
sys.fqhost links to sys.uqhost, but the link is broken. Probably because it
falls later on the same page and it isn't properly resolved. We have had to do
similar for sys.policy_entry_dirname and sys.policy_entry_filename in the past.

This change adds a reference link for sys.uqhost so that it will be sure to
resolve.