### PR TITLE
CFE-2965 Add link reference to sys.uqhost

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -41,3 +41,4 @@
 [body classes]: reference-promise-types.html#classes
 [body common]: reference-components.html#common-control
 [body file]: guide-language-concepts-namespaces.html
+[sys.uqhost]: reference-special-variables-sys.html#sys-uqhost


### PR DESCRIPTION
sys.fqhost links to sys.uqhost, but the link is broken. Probably because it
falls later on the same page and it isn't properly resolved. We have had to do
similar for sys.policy_entry_dirname and sys.policy_entry_filename in the past.

This change adds a reference link for sys.uqhost so that it will be sure to
resolve.

(cherry picked from commit 78ab37ef4bee86008a662912f9afb17a9276bb22)