### PR TITLE
Sort columns in tables generated from dicts

### DIFF
--- a/_scripts/cfdoc_macros.py
+++ b/_scripts/cfdoc_macros.py
@@ -222,7 +222,7 @@ def dictToTable(dictionary):
 	while True:
 		columns = 0
 		line = "| "
-		for key in dictionary.keys():
+		for key in sorted(dictionary.keys()):
 			if row == 0:
 				line += "`" + key + "`"
 				columns =- 1


### PR DESCRIPTION
dict.keys() in Python returns the keys in a random order so if we
use the keys as column names in a tables, we should explicitly
sort them.