### PR TITLE
CFE-1962: Added reference for mpf_extra_autorun_inputs (master)

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -41,6 +41,7 @@
 [sys.policy_hub]: reference-special-variables-sys.html#sys-policy_hub
 [seed_cp]: reference-masterfiles-policy-framework-lib-files.html#seed_cp
 [Append to inputs used by main policy]: reference-masterfiles-policy-framework.html#append-to-inputs-used-by-main-policy
+[mpf_extra_autorun_inputs]: reference-masterfiles-policy-framework.html#additional-automatically-loaded-inputs
 [Append to inputs used by update policy]: reference-masterfiles-policy-framework.html#append-to-inputs-used-by-update-policy
 [Classes and Decisions]: reference-language-concepts-classes
 [language-concepts-classes-hard]: reference-language-concepts-classes.html#hard-classes.html "Language Concepts -> Classes and Decisions: Hard classes"


### PR DESCRIPTION
This target is linked to from the page it's on, but before it, so it needs a
reference to be able to find it.

Ticket: CFE-1962
Changelog: None