### PR TITLE
make assets links relative - 3.15

### DIFF
--- a/_scripts/_publish.sh
+++ b/_scripts/_publish.sh
@@ -19,23 +19,34 @@ fi
 OUTPUT=$WRKDIR/output
 mkdir -p $OUTPUT
 
+# replace absolute style and script links with relative ones. This way, no
+# matter how docs will be served (on https://docs.cfengine.com/docs/3.18/ or
+# http://buildcache.cfengine.com/packages/build-documentation-pr/jenkins-pr-pipeline-7204/output/_site/),
+# these links will still be valid.
+cd documentation-generator/_site
+for source in *.html;
+do
+  sed -i "s/<base href\([^>]*\)>/<!-- base href\1 -->/
+          s/<link href='.*assets\(.*\)>/<link href='assets\1>/
+          s/<script src='.*assets\(.*\)>/<script src='assets\1>/" $source
+done
+cd -
+
 # Pack the site for transfer (its faster to transfer one big file than thousands of small ones)
 # This archive is expected to be unpacked by the build system after the artifacts have been moved to their storage location
 tar -czvf $OUTPUT/packed-for-shipping.tar.gz -C documentation-generator _site
-#cp -a documentation-generator/_site $OUTPUT
 
 ARCHIVE_FILE=cfengine-documentation-$VERSION
 echo "Creating $ARCHIVE_FILE..."
 cd documentation-generator/_site
+# Disable interactive elements (selects and forms) since they won't be working
+# in the downloaded archive
 for source in *.html;
 do
-  sed -i "s/<base href\(.*\)>/<!-- base href\1 -->/" $source
-  sed -i "s/<link href='.*assets\(.*\)>/<link href='assets\1>/" $source
-  sed -i "s/<script src='.*assets\(.*\)>/<script src='assets\1>/" $source
-  sed -i "s/<select/<!-- select/" $source
-  sed -i "s/<\/select>/<\/select -->/" $source
-  sed -i "s/<form/<!-- select/" $source
-  sed -i "s/<\/form>/<\/form -->/" $source
+  sed -i "s/<select/<!-- select/
+          s/<\/select>/<\/select -->/
+          s/<form/<!-- from/
+          s/<\/form>/<\/form -->/" $source
 done
 cd ..
 tar -czf $OUTPUT/$ARCHIVE_FILE.tar.gz _site


### PR DESCRIPTION
so it's possible to have docs preview just by visiting this URL:
http://buildcache.cloud.cfengine.com/packages/build-documentation-pr/267/jenkins-pr-pipeline-7202/output/_site/

(cherry picked from commit ad361e6a0863757267774b8a07e30507f3798733)