### PR TITLE
Centered images in docs

### DIFF
--- a/_assets/css/style.css
+++ b/_assets/css/style.css
@@ -246,6 +246,9 @@ code div {
 img {
     max-height: 100%;
     max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
 }
 
 .tableOverflow {


### PR DESCRIPTION
**Before:**

![before](https://user-images.githubusercontent.com/4048546/155760931-085bb4d6-e63e-444e-9f29-32f013302ff3.png)

**After:**

![centered](https://user-images.githubusercontent.com/4048546/155760943-fbdfd076-6d70-4e0e-8497-77ee6a02cea5.png)

