### PR TITLE
Relax permissions for cleanup - 3.18

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -25,3 +25,5 @@ c=$(buildah from -v $PWD:/nt docs)
 trap "buildah rm $c >/dev/null" EXIT
 buildah run $c bash -x documentation-generator/build/main.sh $BRANCH $PACKAGE_JOB $PACKAGE_UPLOAD_DIRECTORY $PACKAGE_BUILD
 buildah run $c bash -x documentation-generator/_scripts/_publish.sh $BRANCH
+buildah run $c bash -c "sudo chmod -R a+rwX /nt"
+


### PR DESCRIPTION
Issue was that job running inside the container needs to have write
permissions to some dirs. Easiest to achive this is by `chown`'ing
everything to the "jenkins" user inside the container. But then workdir
can't be cleaned up afterwards by "jenkins" user outside the container!

Solution is to chmod a+rwX everything before cleanup.

Ticket: ENT-7467
(cherry picked from commit 9f8be3ab922d804f3c59023361861594f37f4c6b)