### PR TITLE
Update docs container to Ubuntu 22

### DIFF
--- a/_scripts/cfdoc_bootstrap.py
+++ b/_scripts/cfdoc_bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # The MIT License (MIT)
 #
@@ -31,9 +31,9 @@ config = environment.validate(sys.argv[1])
 try:
 	git.createData(config)
 except:
-	print "cfdoc_preprocess: Fatal error generating git tags"
+	print("cfdoc_preprocess: Fatal error generating git tags")
 	sys.stdout.write("       Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 	exit(1)
 
 exit(0)

--- a/_scripts/cfdoc_environment.py
+++ b/_scripts/cfdoc_environment.py
@@ -27,21 +27,21 @@ def validate(branch):
 	config = {}
 	config["WORKDIR"] = os.environ.get('WRKDIR')
 	if config["WORKDIR"] == None:
-		print 'Environment variable WRKDIR is not set, setting it to current working directory'
+		print('Environment variable WRKDIR is not set, setting it to current working directory')
 		config["WORKDIR"] = os.getcwd()
 		os.environ["WRKDIR"] = os.getcwd()
 
 	if not os.path.exists(config["WORKDIR"]):
-		print "Directory WORKDIR not found: " + config["WORKDIR"]
+		print("Directory WORKDIR not found: " + config["WORKDIR"])
 		exit(2)
 		
 	config["project_directory"] = config["WORKDIR"] + "/documentation-generator"
 	if not os.path.exists(config["project_directory"]):
-		print "Directory 'documentation-generator' not found in WORKDIR"
+		print("Directory 'documentation-generator' not found in WORKDIR")
 	
 	config["markdown_directory"] = config["WORKDIR"] + "/documentation"
 	if not os.path.exists(config["markdown_directory"]):
-		print "Directory 'documentation' not found in WORKDIR"
+		print("Directory 'documentation' not found in WORKDIR")
 
 
 	version = branch
@@ -75,9 +75,9 @@ def validate(branch):
 			
 			config[key] = value
 			
-	print 'cfdoc_environment: cwd              = ' + os.getcwd()
-	print '                   config           = '
-	print config
+	print('cfdoc_environment: cwd              = ' + os.getcwd())
+	print('                   config           = ')
+	print(config)
 	
 	markdown_files = []
 	scanDirectory(config["markdown_directory"], "", ".markdown", markdown_files)

--- a/_scripts/cfdoc_git.py
+++ b/_scripts/cfdoc_git.py
@@ -25,7 +25,7 @@ import os
 def createData(config):
 	configpath = config["config_path"]
 	if not os.path.exists(configpath):
-		print "cfdoc_git: \"_config.yml\" not found in " + configpath
+		print("cfdoc_git: \"_config.yml\" not found in " + configpath)
 		return
 
 	cwd = os.getcwd()
@@ -39,8 +39,8 @@ def createData(config):
 			config["revision"] = line
 		git.close()
 	except:
-		print "cfdoc_git: Exception when reading revision"
-		print "cfdoc_git: cwd = " + os.getcwd()
+		print("cfdoc_git: Exception when reading revision")
+		print("cfdoc_git: cwd = " + os.getcwd())
 	
 	branch = "master"
 	try:
@@ -51,12 +51,12 @@ def createData(config):
 			if line.find('*') == 0 and line.find('(') == -1:
 				branch = line.split(' ')[1].rstrip()
 	except:
-		print "cfdoc_git: Exception when reading current branch"
+		print("cfdoc_git: Exception when reading current branch")
 
 	config["branch"] = branch
-	print "cfdoc_git: Updating " + configpath
-	print "           branch   = \'" + config["branch"] + "\'"
-	print "           revision = \'" + config.get("revision", "NOT FOUND!") + "\'"
+	print("cfdoc_git: Updating " + configpath)
+	print("           branch   = \'" + config["branch"] + "\'")
+	print("           revision = \'" + config.get("revision", "NOT FOUND!") + "\'")
 	try:
 		config_file = open(configpath, "a")
 		config_file.write("git-branch: \"" + config.get("branch", "master") + "\"\n")
@@ -64,7 +64,7 @@ def createData(config):
 			config_file.write("git-revision: \"" + config["revision"] + "\"\n")
 		config_file.close()
 	except:
-		print "cfdoc_git: Exception when updating " + configpath
+		print("cfdoc_git: Exception when updating " + configpath)
 
 	os.chdir(cwd)
 

--- a/_scripts/cfdoc_macros.py
+++ b/_scripts/cfdoc_macros.py
@@ -108,16 +108,16 @@ def processFile(markdown, config):
 				new_lines = functor(parameters, config)
 			except:
 				sys.stdout.write("cfdoc_macros: Exception calling ")
-				print functor
+				print(functor)
 				sys.stdout.write("                 in " + config["context_current_file"])
 				sys.stdout.write("(%d): " % config["context_current_line_number"])
 				sys.stdout.write('`%s`' % config["context_current_line"])
 				sys.stdout.write("     Exception : ")
-				print sys.exc_info()
+				print(sys.exc_info())
 		else:
-			print "cfdoc_macros: Unknown function `" + function + "`"
-			print "                 in " + markdown + "(%d)" % markdown_line_number
-			print "                 " + markdown_line
+			print("cfdoc_macros: Unknown function `" + function + "`")
+			print("                 in " + markdown + "(%d)" % markdown_line_number)
+			print("                 " + markdown_line)
 			new_lines += "<!-- " + markdown_line + "-->"
 			
 		if len(new_lines) > 0:
@@ -450,7 +450,7 @@ def document_syntax_map(tree, branch, config):
 			common_attributes = copy.deepcopy(tree.get("classes").get("attributes"))
 		except:
 			qa.Log(config, "cfdoc_macros: syntax_map - no promise type classes?!")
-		for common_attribute in common_attributes.keys():
+		for common_attribute in list(common_attributes.keys()):
 			type_count = 0
 			for type in types:
 				if tree.get(type).get("attributes").get(common_attribute):
@@ -465,7 +465,7 @@ def document_syntax_map(tree, branch, config):
 			lines.append("### [Common Attributes][Promise Types and Attributes#Common Attributes]\n\n")
 			lines.append(document_type("common", common_definition, [], config))
 			
-	excludes = common_attributes.keys()
+	excludes = list(common_attributes.keys())
 	
 	link_map = config["link_map"]
 	for type in types:
@@ -539,7 +539,7 @@ def load_include_file(filename):
 	in_file = open(filename, 'r')
 	lines = in_file.readlines()
 	if len(lines) == 0:
-		print "load_include_file: Failed to load text from: '%s'" % filename
+		print("load_include_file: Failed to load text from: '%s'" % filename)
 		return None
 	return lines
 
@@ -704,7 +704,7 @@ def library_include(parameters, config):
 		config[policy_filename] = policy_json
 		
 	# for all bundles and bodies...
-	for key in policy_json.keys():
+	for key in list(policy_json.keys()):
 		element_list = policy_json[key]
 		current_type = None
 		for element in element_list:
@@ -924,7 +924,7 @@ def redirect(parameters, config):
 
 	target_url = html_map.get(target_anchor)
 	if target_url == None:
-		print "Invalid redirect target '%s', redirecting to home" % target_anchor
+		print("Invalid redirect target '%s', redirecting to home" % target_anchor)
 		target_url = "index.html"
 	
 	markdown_lines.append("<script type=\"text/javascript\">\n")

--- a/_scripts/cfdoc_metadata.py
+++ b/_scripts/cfdoc_metadata.py
@@ -42,14 +42,14 @@ def run(config):
 	for node in category_tree:
 		branch = category_tree.get(node)
 		if branch == None: # orphan
-			print "Orphan in the category tree! Check path to '%s / %s'" % (branch, node)
+			print("Orphan in the category tree! Check path to '%s / %s'" % (branch, node))
 			exit(1)
 		last_branch = branch.split("/")[-1]
 		if last_branch == "":
 			continue
 		parent_branch = category_tree.get(last_branch)
 		if parent_branch == None: # gaps
-			print "ERROR: Missing index file '%s.markdown'" % (branch)
+			print("ERROR: Missing index file '%s.markdown'" % (branch))
 			exit(2)
 
 # parse meta data lines, remove existing header for later reconstruction
@@ -69,7 +69,7 @@ def parseHeader(lines):
 			continue
 		token_list = line.split(":")
 		if len(token_list) != 2:
-			print "parseHeader: ERROR in %s - wrong number of tokens" % line
+			print("parseHeader: ERROR in %s - wrong number of tokens" % line)
 			continue
 		tag = token_list[0].lstrip().rstrip()
 		value = token_list[1].lstrip().lstrip('\"').rstrip().rstrip('\"')
@@ -96,7 +96,7 @@ def processMetaData(file_path, config):
 	if header.get("layout") != "default": # ignore special pages
 		return
 	if not "title" in header: # ignore pages without title, but that's an error at this point
-		print "ERROR! Page without title: %s" % file_name
+		print("ERROR! Page without title: %s" % file_name)
 		return
 
 	categories = []

--- a/_scripts/cfdoc_patch_header_nav.py
+++ b/_scripts/cfdoc_patch_header_nav.py
@@ -20,18 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import json
 import sys
 
 def patch(current_branch):
     url = "https://docs.cfengine.com/docs/branches.json"
-    response = urllib.urlopen(url)
+    response = urllib.request.urlopen(url)
     data = json.loads(response.read())
     with open("_includes/header_nav_options.html", "w") as f:
         for branch in data['docs']:
             selected = ''
             if branch['Version'] == current_branch:
                 selected = ' selected'
-            print >>f, '<option value="%s"%s>%s</option>' % (
-                    branch['Link'], selected, branch['Title'])
+            print('<option value="%s"%s>%s</option>' % (
+                    branch['Link'], selected, branch['Title']), file=f)

--- a/_scripts/cfdoc_postprocess.py
+++ b/_scripts/cfdoc_postprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # The MIT License (MIT)
 #
@@ -32,7 +32,7 @@ try:
 	sourcelinks.run(config)
 except:
 	sys.stdout.write("      Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 	exit(1)
 
 exit(0)

--- a/_scripts/cfdoc_preprocess.py
+++ b/_scripts/cfdoc_preprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # The MIT License (MIT)
 #
@@ -39,32 +39,32 @@ qa.initialize(config)
 try:
 	metadata.run(config)
 except:
-	print "cfdoc_preprocess: Fatal error setting meta data"
+	print("cfdoc_preprocess: Fatal error setting meta data")
 	sys.stdout.write("       Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 	exit(2)
 
 try:
 	linkresolver.run(config)
 except:
-	print "cfdoc_preprocess: Fatal error generating link map"
+	print("cfdoc_preprocess: Fatal error generating link map")
 	sys.stdout.write("       Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 	exit(3)
 
 try:
 	macros.run(config)
 except:
-	print "cfdoc_macros: Error generating documentation from syntax maps"
+	print("cfdoc_macros: Error generating documentation from syntax maps")
 	sys.stdout.write("      Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 
 try: # update the link map with content added by macros
 	linkresolver.run(config)
 except:
-	print "cfdoc_preprocess: Fatal error updating link map"
+	print("cfdoc_preprocess: Fatal error updating link map")
 	sys.stdout.write("       Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 	exit(4)
 
 # generate links to known targets
@@ -75,15 +75,15 @@ linkresolver.apply(config)
 try:
 	printsource.run(config)
 except:
-	print "cfdoc_printsource: Error generating print-pages"
+	print("cfdoc_printsource: Error generating print-pages")
 	sys.stdout.write("      Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 
 try:
 	patch_header_nav.patch(sys.argv[1])
 except:
-	print "cfdoc_patch_header_nav: Error patching header navigation"
+	print("cfdoc_patch_header_nav: Error patching header navigation")
 	sys.stdout.write("      Exception: ")
-	print sys.exc_info()
+	print(sys.exc_info())
 
 exit(0)

--- a/_scripts/cfdoc_printsource.py
+++ b/_scripts/cfdoc_printsource.py
@@ -86,7 +86,7 @@ def run(config):
 	
 	new_pages = dict()
 	print_pages(pagetree, 1, None, new_pages)
-	for new_page in new_pages.keys():
+	for new_page in list(new_pages.keys()):
 		headers = new_pages[new_page]
 		in_file = open(new_page, 'r')
 		lines = in_file.readlines()

--- a/_scripts/cfdoc_qa.py
+++ b/_scripts/cfdoc_qa.py
@@ -84,7 +84,7 @@ def Log(config, string):
 
 	logfile.write("\n* %s\n" % string)
 	logfile.write("    * Triggered by: `%s` (%d)\n" % (os.path.relpath(config["context_current_file"]), config["context_current_line_number"]))
-	print "%s (%d): %s" % (os.path.relpath(config["context_current_file"]), config["context_current_line_number"], string)
+	print("%s (%d): %s" % (os.path.relpath(config["context_current_file"]), config["context_current_line_number"], string))
 
 	logfile.writelines(original[line_offset:])
 	logfile.close()

--- a/_scripts/cfdoc_sourcelinks.py
+++ b/_scripts/cfdoc_sourcelinks.py
@@ -40,8 +40,8 @@ def verifyRegex(regex, tests):
         expected = test[1]
         actual = regex.search(line) != None
         if actual != expected:
-            print "Programming error: regex '%s' doesn't match '%s' correctly!" % (regex, line)
-            print "    expected result: %s" % expected
+            print("Programming error: regex '%s' doesn't match '%s' correctly!" % (regex, line))
+            print("    expected result: %s" % expected)
             exit(-1)
 
 def unresolvedLinkRegex():
@@ -114,7 +114,7 @@ def addLinkToSource(file_name,config):
         lines = in_file.readlines()
         in_file.close()
     except:
-        print "cfdoc_sourcelinks: Error opening " + html_file
+        print("cfdoc_sourcelinks: Error opening " + html_file)
         return 0 # tolerate missing HTML files
 
     new_html_file = html_file + ".new"
@@ -122,10 +122,10 @@ def addLinkToSource(file_name,config):
     for line in lines:
         line = line.replace("\">markdown source</a>]", source_file + "\">markdown source</a>]")
         if unresolved_link.search(line) != None:
-            print "Unresolved link in '%s', html-line '%s'\n\n Perhaps you need to add an entry to to _references.md in the documentation-generator repository" % (file_name, line)
+            print("Unresolved link in '%s', html-line '%s'\n\n Perhaps you need to add an entry to to _references.md in the documentation-generator repository" % (file_name, line))
             error_count += 1
         if unexpanded_macro.search(line) != None:
-            print "Unexpanded macro in '%s', html-line '%s'\n" % (file_name, line)
+            print("Unexpanded macro in '%s', html-line '%s'\n" % (file_name, line))
             error_count += 1
         out_file.write(line)
     out_file.close()

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 # We need sudo before all
 RUN apt-get -qy update && \

--- a/build/main.sh
+++ b/build/main.sh
@@ -74,7 +74,7 @@ done
 wget -O- $FLAG_FILE_URL
 
 echo "Detecting version"
-HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_16
+HUB_DIR_NAME=PACKAGES_HUB_x86_64_linux_ubuntu_18
 HUB_DIR_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/$HUB_DIR_NAME/"
 HUB_PACKAGE_NAME="$(wget $HUB_DIR_URL -O- | sed '/deb/!d;s/.*"\([^"]*\.deb\)".*/\1/')"
 

--- a/build/run.sh
+++ b/build/run.sh
@@ -3,8 +3,8 @@
 set -ex
 trap "echo FAILURE" ERR
 
-if ! buildah inspect docs >/dev/null 2>&1; then
-  buildah build-using-dockerfile -t docs documentation-generator/build
+if ! buildah inspect docs22 >/dev/null 2>&1; then
+  buildah build-using-dockerfile -t docs22 documentation-generator/build
 fi
 
 # current path must have the following repos cloned:
@@ -21,7 +21,7 @@ true "${PACKAGE_JOB?undefined}"
 true "${PACKAGE_UPLOAD_DIRECTORY?undefined}"
 true "${PACKAGE_BUILD?undefined}"
 
-c=$(buildah from -v $PWD:/nt docs)
+c=$(buildah from -v $PWD:/nt docs22)
 trap "buildah rm $c >/dev/null" EXIT
 buildah run $c bash -x documentation-generator/build/main.sh $BRANCH $PACKAGE_JOB $PACKAGE_UPLOAD_DIRECTORY $PACKAGE_BUILD
 buildah run $c bash -x documentation-generator/_scripts/_publish.sh $BRANCH


### PR DESCRIPTION
Ticket: ENT-8470

Changes:
* make install script fail on error (set -e)
* use gpg2 instead of gpg
* install ruby without rubygems (before rvm tried to install rubygems
  and failed and we ignored it)
* install ruby without openssl (because ruby compiled against openssl
  1.0 and modern distros don't ship it. And we don't need openssl in
  ruby anyway)
* use python3 instead of python2
* Changed Python scripts from 2 to 3 using 2to3.py