### PR TITLE
Fixed docs building (3.18)

### DIFF
--- a/build/main.sh
+++ b/build/main.sh
@@ -15,7 +15,7 @@ export PACKAGE_UPLOAD_DIRECTORY=$3
 export PACKAGE_BUILD=$4
 
 export JOB_TO_UPLOAD=$PACKAGE_JOB
-export FLAG_FILE_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/PACKAGES_HUB_x86_64_linux_ubuntu_16/core-commitID"
+export FLAG_FILE_URL="http://buildcache.cfengine.com/packages/$PACKAGE_JOB/$PACKAGE_UPLOAD_DIRECTORY/PACKAGES_HUB_x86_64_linux_ubuntu_18/core-commitID"
 export NO_OUTPUT_DIR=1
 
 env


### PR DESCRIPTION
Changed FLAG_FILE_URL variable from ubuntu 16 to 18.

(cherry picked from commit 4545ce83167244c546cd1a22a7dd875b2a0c73fa)