### PR TITLE
Avoid creating titles inside code blocks

### DIFF
--- a/_scripts/cfdoc_macros.py
+++ b/_scripts/cfdoc_macros.py
@@ -62,7 +62,7 @@ def processFile(markdown, config):
 			current_html = markdown_line.split('alias: ')
 			current_html = current_html[1].rstrip()
 			config["context_current_html"] = current_html
-		elif markdown_line[0] == '#':
+		elif not in_pre and markdown_line[0] == '#':
 			for header_depth in range(1,6):
 				header_marker = "#" * header_depth + " "
 				if markdown_line.find(header_marker) == 0:


### PR DESCRIPTION
When de-indenting some code blocks I found that for the purposes
of our macros and auto-linking magic, we will consider lines
starting with # as markdown headings / titles, even when they
are inside triple-backticked code blocks.

This should be fixed, but I anticipate the fix might cause some
problems. (Maybe).
